### PR TITLE
Update action config to use the built action in dist/

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,4 @@ outputs:
     description: "IP address of the server"
 runs:
   using: 'node16'
-  main: 'index.js'
+  main: 'dist/index.js'


### PR DESCRIPTION
We build this action and commit it to `dist/` rather than committing the `node_modules` directory, which means we have to use `dist/index.js` as the entrypoint to avoid missing dependency errors.